### PR TITLE
feat: ensure --ram allocated only 70% of total allocated to process t…

### DIFF
--- a/modules/local/fragpipe/main.nf
+++ b/modules/local/fragpipe/main.nf
@@ -188,7 +188,7 @@ process FRAGPIPE {
     fi
 
     echo "FragPipe executable: \$FRAGPIPE_CMD"
-    echo "RAM: ${task.memory.toGiga()} GB"
+    echo "RAM: ${(task.memory.toGiga() * 0.7) as Integer} GB (70% of ${task.memory.toGiga()} GB allocated)"
     echo "Threads: ${threads}"
     echo ""
     echo "Starting FragPipe headless execution..."
@@ -202,7 +202,7 @@ process FRAGPIPE {
         --manifest \$WORK_DIR/manifest.fp-manifest \\
         --workdir \$WORK_DIR/results \\
         --config-tools-folder \$WORK_DIR/fragpipe_tools \\
-        --ram ${task.memory.toGiga()} \\
+        --ram ${(task.memory.toGiga() * 0.7) as Integer} \\
         --threads ${threads} \\
         $args \\
         2>&1 | tee fragpipe_execution.log


### PR DESCRIPTION
…o prevent java runtime malloc error for large datasets

<!--
# sheynkmanlab/lrp2 pull request

Many thanks for contributing to sheynkmanlab/lrp2!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sheynkmanlab/lrp2/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sheynkmanlab/lrp2/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
