### PR TITLE
fix: resolve composite SQANTI gene labels via matched reference trans…

### DIFF
--- a/bin/00_generate_hashids.R
+++ b/bin/00_generate_hashids.R
@@ -200,7 +200,7 @@ cat("\nGenerated hash IDs for ", nrow(hashids), " transcripts\n")
 # Step 2: Read SQANTI classification and reference GTF
 # =============================================================================
 
-cat("\nSTEP 2: Reading SQANTI classification and GENCODE reference")
+cat("\nSTEP 2: Reading SQANTI classification and GENCODE reference, resolving composite gene labels")
 
 sqanti = read_tsv(class_file, show_col_types = FALSE) %>%
   filter(!is.na(associated_gene), !str_starts(associated_gene, "novelGene"))
@@ -211,17 +211,37 @@ reference_df = as.data.frame(reference)
 
 reference_gene = reference_df %>%
   filter(type == "transcript") %>%
-  select(associated_gene = gene_id,
+  select(ref_gene = gene_id,
          gene_name = any_of(c("gene_name", "gene")),
          gene_type = any_of(c("gene_type", "gene_biotype"))) %>%
   distinct()
 
 reference_transcript = reference_df %>%
   filter(type == "transcript") %>%
-  select(associated_gene = gene_id,
-         associated_transcript = transcript_id,
+  select(ref_gene = gene_id,
+         ref_transcript = transcript_id,
          any_of("transcript_name")) %>%
   distinct()
+
+# Resolve multi-gene (ENSG_A_ENSG_B) mapping based on associated transcript for FSM and ISM
+# NIC/NNC keep SQANTI's call
+n_composite = sum(str_detect(sqanti$associated_gene, "_"))
+
+sqanti %<>% 
+  select(original_transcript_id = isoform, associated_gene, associated_transcript, structural_category) %>%
+  left_join(reference_transcript, by = c("associated_transcript" = "ref_transcript")) %>%
+  mutate(associated_gene = coalesce(ref_gene, associated_gene)) %>%
+  select(-ref_gene) %>%
+  left_join(reference_gene, by = c("associated_gene" = "ref_gene"))
+
+n_remaining = sum(str_detect(sqanti$associated_gene, "_"))
+remaining_by_cat = sqanti %>%
+  filter(str_detect(associated_gene, "_")) %>%
+  count(structural_category)
+
+cat("\nResolved ", n_composite - n_remaining, " of ", n_composite, " composite gene labels\n")
+cat("  Remaining: ", paste(remaining_by_cat$structural_category, remaining_by_cat$n,
+                           sep = "=", collapse = ", "), "\n")
 
 # =============================================================================
 # STEP 3: Build mapping table with new pipeline transcript IDs
@@ -231,21 +251,15 @@ cat("\nSTEP 3: Building pipeline transcript IDs")
 
 # Combine hash IDs with SQANTI classification and gene names
 mapping = hashids %>%
-  dplyr::rename(original_transcript_id = transcript_id) %>%
-  inner_join(sqanti %>% select(original_transcript_id = isoform,
-                               associated_gene,
-                               associated_transcript,
-                               structural_category),
-             by = "original_transcript_id") %>%
-  left_join(reference_gene, by = "associated_gene") %>%
-  left_join(reference_transcript, by = c("associated_gene", "associated_transcript"))
+  dplyr::select(original_transcript_id = transcript_id, hash_id) %>%
+  inner_join(sqanti, by = "original_transcript_id")
+
+cat("\nMapped ", nrow(mapping), " of ", nrow(hashids), " hashed transcripts to SQANTI classification entries\n")
 
 # Gene label: prefer gene_name, fall back to gene_id
+# Junction hash (without chr and strand)
 mapping %<>%
-  mutate(gene_label = if_else(!is.na(gene_name) & gene_name != "", gene_name, associated_gene))
-
-# Junction hash (without chr and strand) for novel transcript IDs
-mapping %<>%
+  mutate(gene_label = if_else(!is.na(gene_name) & gene_name != "", gene_name, associated_gene)) %>%
   mutate(junction_hash = extract_junction_hash(hash_id))
 
 # New transcript ID:
@@ -265,7 +279,7 @@ mapping %<>%
 # STEP 4: Check for redundant isoform IDs
 # =============================================================================
 
-cat("\nSTEP 4: Checking for isoform ID redundancy")
+cat("\nSTEP 4: Checking for isoform ID redundancy\n")
 
 # Extract chromosome from hash_id for chrX/Y redundancy
 mapping %<>% mutate(chrom = str_extract(hash_id, "^[^_]+"))
@@ -292,7 +306,7 @@ if (nrow(dupe_ids) > 0) {
   if (nrow(chr_dupes) > 0) {
     n_chr = n_distinct(chr_dupes$isoform_id)
     cat("Chr gene redundancy e.g., chrX/chrY: ", n_chr, " isoform IDs on multiple chromosomes (",
-            nrow(chr_dupes), " total rows). Appending chromosome to gene label.")
+            nrow(chr_dupes), " total rows). Appending chromosome to gene label.\n")
     
     chr_fix = chr_dupes %>%
       mutate(isoform_id = paste0(gene_label, ".", chrom, "::", junction_hash))
@@ -308,7 +322,7 @@ if (nrow(dupe_ids) > 0) {
   if (nrow(other_dupes) > 0) {
     n_other = n_distinct(other_dupes$isoform_id)
     cat("TSS/TES redundancy: ", n_other, " isoform IDs with same junctions in the same gene, different ends (",
-            nrow(other_dupes), " total rows). Appending ::1, ::2, etc.")
+            nrow(other_dupes), " total rows). Appending ::1, ::2, etc.\n")
     
     other_fix = other_dupes %>%
       group_by(isoform_id) %>%
@@ -323,7 +337,7 @@ if (nrow(dupe_ids) > 0) {
   }
   
 } else {
-  cat("No isoform ID redundancy detected")
+  cat("No isoform ID redundancy detected\n")
 }
 
 # =============================================================================
@@ -332,6 +346,7 @@ if (nrow(dupe_ids) > 0) {
 
 cat("\nSTEP 5: Writing mapping file\n")
 
+# Strips transcript id and name labels for ISMs
 output_mapping = mapping %>%
   mutate(
     reference_transcript_id = if_else(structural_category == "full-splice_match",

--- a/bin/02_filter_sqanti_transcripts.R
+++ b/bin/02_filter_sqanti_transcripts.R
@@ -215,12 +215,14 @@ sqanti_df %<>%
 original_isoform_ids = sqanti_df$isoform
 
 # Replace original isoform IDs with new pipeline isoform_id throughout
+# Use resolved gene_id from 'GENERATE HASHIDS' script - resolving composite gene mappings
 sqanti_df_full = sqanti_df %>%
-  inner_join(mapping %>% select(isoform_id, original_transcript_id,
+  inner_join(mapping %>% select(isoform_id, original_transcript_id, reference_gene_id,
                                 any_of("gene_type"), any_of("gene_name")),
              by = c("isoform" = "original_transcript_id")) %>%
-  mutate(isoform = isoform_id) %>%
-  select(-isoform_id)
+  mutate(isoform = isoform_id,
+         associated_gene = reference_gene_id) %>%
+  select(-isoform_id, -reference_gene_id)
 
 # Build the hashids + CPM table using new isoform IDs
 all_ids = mapping %>%


### PR DESCRIPTION
…cript

SQANTI emits ENSGA_ENSGB in associated_gene for transcripts overlapping two loci, which failed the reference gene lookup and left gene_type NA. FSM/ISM transcripts were then silently dropped by the protein-coding filter and mislabelled not_protein_coding.

FSM/ISM now inherit the gene of their matched reference transcript; NIC/NNC and fusions keep SQANTI's call. Propagates resolved gene IDs so all downstream outputs carry the corrected assignment.

<!--
# sheynkmanlab/lrp2 pull request

Many thanks for contributing to sheynkmanlab/lrp2!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sheynkmanlab/lrp2/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sheynkmanlab/lrp2/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
